### PR TITLE
Update `string.(lift|lower)_memory` to read `u32` + `string.size`

### DIFF
--- a/proposals/interface-types/working-notes/Instructions.md
+++ b/proposals/interface-types/working-notes/Instructions.md
@@ -103,7 +103,7 @@ string.size #encoding
 
 The type of this instruction is:
 ```
-[string] -> [i32]
+[string] -> [u32]
 ```
 
 The output is the number of bytes needed to represent the input string in `#encoding`.
@@ -125,7 +125,7 @@ string.lift_memory #memidx #encoding
 
 The type of this instruction is:
 ```
-[$base: i32, $len: i32] -> [string]
+[$base: u32, $len: u32] -> [string]
 ```
 
 The output is a sequence of unicode code points taken by interpreting `store.memory[$memidx].bytes[$base .. $base + $len]` with `#encoding`.
@@ -141,7 +141,7 @@ string.lower_memory #memidx #encoding
 
 The type of this instruction is:
 ```
-[$base: i32, string] -> []
+[$base: u32, string] -> []
 ```
 
 The instruction will encode the string with `#encoding` into the memory specified by `#memidx` at the offset `$base`.


### PR DESCRIPTION
Initially, `string.lift_memory` reads a pair of `i32` to represent the pointer/the base, and the length of the string. `string.lower_memory` also reads a `i32` to represent the pointer/the base. Finally, `string.size` returns a `i32`.

This patch proposes to change `i32` by `u32`. Indeed, a pointer/a base cannot be negative, so it can be represented by `u32`. The length of the string can also not be negative, so it is by definition a `u32`.

In addition, using `i32` restricts ourself to a memory of 2Gib, whilst `u32` allows to address a memory of 4Gib.

Thoughts?

(Originates from https://github.com/wasmerio/wasmer/pull/1329 and https://github.com/wasmerio/wasmer/pull/1337)